### PR TITLE
Fix Hyprland image build and add Lan Mouse

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,10 +192,10 @@ jobs:
 
       # Sign container
       - uses: sigstore/cosign-installer@v4.1.2
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && success()
 
       - name: Sign container image
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && success()
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ steps.build_image.outputs.image }}@${TAGS}
         env:

--- a/build/hyprland/build.sh
+++ b/build/hyprland/build.sh
@@ -45,6 +45,9 @@ hyprland_packages=(
   # Desktop components
   waybar SwayNotificationCenter nwg-displays quickshell
 
+  # Lan Mouse direct binary runtime deps (GTK/libadwaita frontend plus X11 fallback/input libraries)
+  libadwaita gtk4 libX11 libXtst
+
   # Screen locking and power management
   hyprlock hypridle
 
@@ -60,7 +63,7 @@ hyprland_packages=(
   network-manager-applet gvfs gvfs-mtp
   inxi fastfetch loupe mousepad qalculate-gtk yad
 
-  # Scripting and helper tools
+  # Scripting and helper tools (curl/jq are also used to resolve the Lan Mouse GitHub release)
   bc curl findutils gawk git ImageMagick jq openssl unzip wget2
   wl-clipboard cliphist xdg-user-dirs xdg-utils
   python3-requests python3-pip python3-pyquery
@@ -115,6 +118,7 @@ else
 fi
 
 RELEASE="$(rpm -E %fedora)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "Running base configuration for Fedora $RELEASE"
 source ../base/build.sh
@@ -142,6 +146,9 @@ fi
 echo "Installing Hyprland and dependencies"
 rpm-ostree install "${hyprland_packages[@]}"
 
+echo "Installing Lan Mouse"
+"${SCRIPT_DIR}/install-lan-mouse.sh"
+
 # NOTE: Plugin build dependencies are NOT installed here due to gcc version conflicts
 # with the base image. Instead, users should use the hyprland-build distrobox container.
 # Run: ujust setup-hyprland-build create
@@ -149,5 +156,4 @@ echo "Skipping plugin build dependencies (use hyprland-build distrobox instead)"
 
 # Install ujust recipe for hyprland plugin building
 echo "Installing hyprland-build ujust recipe"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 install -Dm644 "${SCRIPT_DIR}/justfiles/60-custom.just" /usr/share/ublue-os/just/60-custom.just

--- a/build/hyprland/build.sh
+++ b/build/hyprland/build.sh
@@ -37,8 +37,7 @@ hyprland_packages=(
   kitty wlogout
 
   # Theming and appearance
-  kvantum qt5ct qt6ct qt6-qtsvg nwg-look hyprcursor hyprland-qt-support
-  hyprland-guiutils
+  kvantum qt5ct qt6ct qt6-qtsvg nwg-look hyprcursor hyprland-guiutils
 
   # Wallpaper and color
   swww wallust
@@ -127,15 +126,17 @@ for repo in "${copr_repos[@]}"; do
   dnf5 copr enable -y "$repo"
 done
 
-# Add polkit agent - hyprpolkitagent requires Qt 6.9 but NVIDIA images ship Qt 6.10
-# Base bazzite image includes polkit-kde, so we fall back to that when hyprpolkitagent won't work
+# Add Qt-coupled Hyprland helpers only when the base image Qt is new enough.
+# bazzite-nvidia can lag Fedora's Qt updates, and rpm-ostree cannot layer
+# packages that require replacing qt6-qtbase from the base commit.
 QT_VERSION=$(rpm -q qt6-qtbase --queryformat '%{VERSION}' 2>/dev/null || echo "unknown")
 echo "Detected Qt version: $QT_VERSION"
-if [[ "$QT_VERSION" == 6.10* ]]; then
-  echo "Qt 6.10 detected - using polkit-kde from base image (hyprpolkitagent requires Qt 6.9)"
+if [[ "$QT_VERSION" == "unknown" ]] ||
+   [[ "$(printf '%s\n' "6.11" "$QT_VERSION" | sort -V | head -n1)" != "6.11" ]]; then
+  echo "Qt $QT_VERSION is below 6.11 - using polkit-kde from the base image and skipping hyprland-qt-support"
 else
-  echo "Using hyprpolkitagent"
-  hyprland_packages+=(hyprpolkitagent)
+  echo "Using Hyprland Qt support packages"
+  hyprland_packages+=(hyprland-qt-support hyprpolkitagent)
 fi
 
 echo "Installing Hyprland and dependencies"

--- a/build/hyprland/install-lan-mouse.sh
+++ b/build/hyprland/install-lan-mouse.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Install the newest non-draft Lan Mouse GitHub release, including prereleases.
+
+if [[ "${TRACE:-0}" -ne 0 ]]; then
+  set -ouex pipefail
+else
+  set -oue pipefail
+fi
+
+api_url="https://api.github.com/repos/feschber/lan-mouse/releases"
+asset_name=""
+release_json=""
+tmpdir=""
+
+case "$(uname -m)" in
+  x86_64)
+    asset_name="lan-mouse-linux-x86_64"
+    ;;
+  aarch64|arm64)
+    asset_name="lan-mouse-linux-arm64"
+    ;;
+  *)
+    echo "Unsupported architecture for Lan Mouse: $(uname -m)"
+    exit 1
+    ;;
+esac
+
+cleanup() {
+  if [[ -n "$tmpdir" ]]; then
+    rm -rf "$tmpdir"
+  fi
+}
+trap cleanup EXIT
+
+tmpdir="$(mktemp -d)"
+release_json="${tmpdir}/releases.json"
+
+echo "Resolving latest Lan Mouse release from GitHub"
+curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
+  --header "Accept: application/vnd.github+json" \
+  "$api_url" \
+  --output "$release_json"
+
+selected_release="$(jq -c 'map(select(.draft | not)) | sort_by(.published_at // .created_at) | last' "$release_json")"
+selected_tag="$(jq -r '.tag_name // empty' <<< "$selected_release")"
+asset_url="$(jq -r --arg name "$asset_name" '.assets[]? | select(.name == $name) | .browser_download_url // empty' <<< "$selected_release")"
+asset_digest="$(jq -r --arg name "$asset_name" '.assets[]? | select(.name == $name) | .digest // empty' <<< "$selected_release")"
+
+if [[ -z "$selected_tag" || -z "$asset_url" ]]; then
+  echo "Unable to find ${asset_name} in the latest Lan Mouse release"
+  jq -r '.[] | select(.draft | not) | "\(.tag_name) prerelease=\(.prerelease) published=\(.published_at)"' "$release_json"
+  exit 1
+fi
+
+echo "Installing Lan Mouse ${selected_tag} from ${asset_url}"
+curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
+  "$asset_url" \
+  --output "${tmpdir}/lan-mouse"
+
+if [[ "$asset_digest" == sha256:* ]]; then
+  echo "${asset_digest#sha256:}  ${tmpdir}/lan-mouse" | sha256sum --check -
+else
+  echo "Lan Mouse release asset is missing a sha256 digest"
+  exit 1
+fi
+
+install -Dm0755 "${tmpdir}/lan-mouse" /usr/bin/lan-mouse
+
+raw_base="https://raw.githubusercontent.com/feschber/lan-mouse/${selected_tag}"
+
+curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
+  "${raw_base}/de.feschber.LanMouse.desktop" \
+  --output "${tmpdir}/de.feschber.LanMouse.desktop"
+install -Dm0644 "${tmpdir}/de.feschber.LanMouse.desktop" /usr/share/applications/de.feschber.LanMouse.desktop
+
+curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
+  "${raw_base}/lan-mouse-gtk/resources/de.feschber.LanMouse.svg" \
+  --output "${tmpdir}/de.feschber.LanMouse.svg"
+install -Dm0644 "${tmpdir}/de.feschber.LanMouse.svg" /usr/share/icons/hicolor/scalable/apps/de.feschber.LanMouse.svg
+
+curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
+  "${raw_base}/firewall/lan-mouse.xml" \
+  --output "${tmpdir}/lan-mouse.xml"
+install -Dm0644 "${tmpdir}/lan-mouse.xml" /usr/lib/firewalld/services/lan-mouse.xml
+
+curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
+  "${raw_base}/service/lan-mouse.service" \
+  --output "${tmpdir}/lan-mouse.service"
+install -Dm0644 "${tmpdir}/lan-mouse.service" /usr/lib/systemd/user/lan-mouse.service
+
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+  gtk-update-icon-cache -q /usr/share/icons/hicolor || true
+fi


### PR DESCRIPTION
## Summary
- Gate Hyprland Qt helper packages behind the Qt 6.11 runtime requirement so current Bazzite images can build.
- Add a dedicated Lan Mouse installer script that resolves the newest non-draft GitHub release, verifies the published sha256 digest, and installs the binary plus desktop, icon, firewalld, and systemd user service files.
- Keep curl/jq and runtime dependency comments tied to the Lan Mouse install path.

## Verification
- `bash -n build/hyprland/build.sh build/hyprland/install-lan-mouse.sh`
- `./build-local.sh hyprland nvidia`
- `podman run --rm phalanx-hyprland-nvidia:local ...`
- `git diff --check`