### PR TITLE
fix(workstation): enforce valid non-system GID for onepassword-cli group

### DIFF
--- a/build/workstation/build.sh
+++ b/build/workstation/build.sh
@@ -29,6 +29,13 @@ source ../hyprland/build.sh
 echo "Installing Workstation packages"
 rpm-ostree install "${workstation_packages[@]}"
 
+echo "Creating 1Password CLI sysusers configuration"
+# Pre-create the onepassword-cli group with a GID of 11005 (>= 1000)
+# This ensures that when the layered 1password-cli package is installed/updated on the host,
+# its files are owned by a valid user-level GID rather than a system GID under 1000.
+mkdir -p /usr/lib/sysusers.d
+echo "g onepassword-cli 11005 -" > /usr/lib/sysusers.d/10-1password-cli.conf
+
 echo "Adding 1Password repository"
 # Add 1Password official RPM repository
 cat > /etc/yum.repos.d/1password.repo << 'EOF'


### PR DESCRIPTION
Pre-seed systemd-sysusers configuration to assign onepassword-cli a specific GID of 11005 (>= 1000).

In recent versions of the 1Password desktop app (and the CLI Biometric Unlock integration), the desktop app strictly validates the GID of the connecting process. If the GID is < 1000 (a system group, such as 958 dynamically assigned during rpm-ostree package layering), the connection is forcibly rejected with "invalid group attempted to connect, rejecting remote" and "PipeAuthError(NoCreds)", causing "read: connection reset" in the CLI.

By pre-seeding the 10-1password-cli.conf sysusers file inside the immutable workstation image with GID 11005, we ensure that:
- systemd-sysusers creates the group with a non-system GID >= 1000.
- The layered 1password-cli package on the host correctly assigns the GID 11005 to the /usr/bin/op binary.
- Potential GID conflicts with standard local user accounts (which typically use lower GIDs like 1000-1010) are minimized.

References:
- https://developer.1password.com/docs/cli/app-integration-security/
- https://app-updates.agilebits.com/product_history/CLI2

