### PR TITLE
fix(workstation): materialize onepassword-cli group in base /usr/lib/group

### DIFF
--- a/build/workstation/build.sh
+++ b/build/workstation/build.sh
@@ -35,6 +35,9 @@ echo "Creating 1Password CLI sysusers configuration"
 # its files are owned by a valid user-level GID rather than a system GID under 1000.
 mkdir -p /usr/lib/sysusers.d
 echo "g onepassword-cli 11005 -" > /usr/lib/sysusers.d/10-1password-cli.conf
+# Force materialization of the group in /usr/lib/group during image compilation
+# so that the offline rpm-ostree package layerer on the host can resolve the group owner of /usr/bin/op.
+echo "onepassword-cli:x:11005:" >> /usr/lib/group
 
 echo "Adding 1Password repository"
 # Add 1Password official RPM repository


### PR DESCRIPTION
Explicitly append the "onepassword-cli" group entry with GID 11005 to /usr/lib/group during the OCI image build.

Although we previously added the systemd-sysusers configuration (10-1password-cli.conf), systemd-sysusers does not execute automatically inside container builds. Consequently, the group was never materialized inside /usr/lib/group of the compiled base image.

Because /usr is completely read-only on OSTree systems, any files in /usr (such as /usr/bin/op provided by 1password-cli) must be owned by a group defined in the base image's read-only group file (/usr/lib/group). If the group is missing during package layering, the offline rpm-ostree package layerer on the host panics with:
"While applying overrides for pkg 1password-cli: Could not find group 'onepassword-cli' in group file"

Writing this group directly to /usr/lib/group during image compilation resolves the lookup crash on the host and allows the layered package to install successfully.

References:
- https://github.com/coreos/rpm-ostree/issues/5333

