### PR TITLE
hyprland: layer swaylock-plugin-screensaver + Xvfb for the lockscreen tooling

### DIFF
--- a/build/hyprland/build.sh
+++ b/build/hyprland/build.sh
@@ -26,7 +26,8 @@ copr_repos=(
     # For swww
     alebastr/sway-extras
 
-    # swaylock-plugin (+ windowtolayer) F44 RPMs for the xscreensaver lockscreen
+    # swaylock-plugin (+ -screensaver tooling, windowtolayer) F44 RPMs for the
+    # xscreensaver lockscreen
     syndr/swaylock-plugin
 )
 
@@ -55,11 +56,16 @@ hyprland_packages=(
   hyprlock hypridle
 
   # Screensaver lockscreen (swaylock-plugin + xscreensaver hacks, incl. GL)
-  # swaylock-plugin/windowtolayer come from the syndr/swaylock-plugin COPR;
-  # the xscreensaver-* hacks come from Fedora. hyprlock is kept as the fallback.
-  swaylock-plugin windowtolayer
+  # swaylock-plugin/-screensaver/windowtolayer come from the syndr/swaylock-plugin
+  # COPR; the xscreensaver-* hacks come from Fedora. hyprlock stays the fallback.
+  # swaylock-plugin-screensaver (>= 1.8.6.2) ships the canonical lock launcher,
+  # rofi hack picker, and thumbnail generator in /usr/bin (the dotfiles' copies
+  # become thin wrappers around them). Xvfb powers the thumbnail generator;
+  # ImageMagick, its other half, is already under "Scripting and helper tools".
+  swaylock-plugin swaylock-plugin-screensaver windowtolayer
   xscreensaver-extras xscreensaver-extras-gss
   xscreensaver-gl xscreensaver-gl-base
+  xorg-x11-server-Xvfb
 
   # Screenshot tools
   grim slurp swappy

--- a/docs/adr/provide-swaylock-plugin-screensaver-lockscreen-deps.md
+++ b/docs/adr/provide-swaylock-plugin-screensaver-lockscreen-deps.md
@@ -49,6 +49,12 @@ Ship the system-level runtime dependencies in the `hyprland` variant image
    and `rpm-ostree install swaylock-plugin windowtolayer`. This matches the
    existing pattern; only the COPR owner needs a (free) Fedora account, while the
    image build and end users consume the repo anonymously.
+   *Amended 2026-07-07:* also install `swaylock-plugin-screensaver` (subpackage,
+   >= 1.8.6.2) — the canonical lock launcher / rofi hack picker / thumbnail
+   generator upstreamed from the dotfiles (fork PR #7), plus
+   `xorg-x11-server-Xvfb` for the thumbnail generator (ImageMagick was already
+   in the image). The dotfiles' script copies become thin wrappers over the
+   packaged `/usr/bin` tools.
 2. **Source: the `syndr` fork, not upstream `mstoeckl`.** The fork's `SIGCHLD`
    reset is mandatory for the lockscreen to function; the RPM is built from it.
 3. **xscreensaver hacks, including GL, from Fedora:** `xscreensaver-extras`,
@@ -108,7 +114,8 @@ RPM-owned, at `/usr/libexec/swaylock-plugin/example_xwayland_wrapper.py`, so
 - swaylock-plugin fork (RPM source): `https://github.com/syndr/swaylock-plugin`
   (`main`) — carries the mandatory `SIGCHLD` reset + multi-output fix.
 - windowtolayer: `https://gitlab.freedesktop.org/mstoeckl/windowtolayer`.
-- COPR: `syndr/swaylock-plugin` (packages `swaylock-plugin`, `windowtolayer`;
+- COPR: `syndr/swaylock-plugin` (packages `swaylock-plugin`,
+  `swaylock-plugin-screensaver`, `windowtolayer`;
   chroots `fedora-43-{x86_64,aarch64}`, `fedora-44-{x86_64,aarch64}`).
 - Config half: `syndr/hyprland-wm-config` @ `feat/swaylock-screensaver-lockscreen`.
 - ostree `/var` + tmpfiles: <https://coreos.github.io/rpm-ostree/container/>,


### PR DESCRIPTION
Follow-up to #39. The swaylock-plugin fork now packages the screensaver tooling itself — [syndr/swaylock-plugin#7](https://github.com/syndr/swaylock-plugin/pull/7) (merged, released as v1.8.6.2, live in the COPR: `swaylock-plugin-screensaver-1.8.6.2-1.syndr.fc44` verified downloadable).

Changes to `build/hyprland/build.sh`:

- **`swaylock-plugin-screensaver`** — the canonical lock launcher (`swaylock-screensaver`, fail-safe degrade chain, screenshot fallback background), rofi hack picker (`swaylock-screensaver-select`: thumbnails, descriptions, live preview, `hacks.conf` per-hack flags with an edit shortcut), and local thumbnail generator (`swaylock-screensaver-shots`), all in `/usr/bin`. The dotfiles' script copies become thin wrappers around these.
- **`xorg-x11-server-Xvfb`** — powers the thumbnail generator (each hack runs briefly on a headless display and a frame is captured); ImageMagick, its other half, is already in the image.

ADR `provide-swaylock-plugin-screensaver-lockscreen-deps.md` amended accordingly (decision point 1 + references).

No new repos, no PAM/tmpfiles changes — pure package additions from the already-enabled COPR and Fedora.