### PR TITLE
fix(hyprland): stop portal backends failing at logout, spamming fumon

### DIFF
--- a/build/hyprland/build.sh
+++ b/build/hyprland/build.sh
@@ -169,6 +169,17 @@ echo "Installing swaylock-plugin xkb tmpfiles config"
 install -Dm644 "${SCRIPT_DIR}/files/tmpfiles.d/swaylock-plugin-xkb.conf" \
   /usr/lib/tmpfiles.d/swaylock-plugin-xkb.conf
 
+# Portal backends must not be D-Bus-activated outside a graphical session:
+# at logout under Hyprland/uwsm the compositor dies first, then
+# xdg-desktop-portal re-activates its backends while closing portal sessions,
+# and the doomed start ("cannot open display") leaves the unit failed for
+# fumon to report at the next login. See files/systemd-user/ for details.
+echo "Installing portal-backend graphical-session drop-ins"
+for unit in xdg-desktop-portal-gtk plasma-xdg-desktop-portal-kde; do
+  install -Dm644 "${SCRIPT_DIR}/files/systemd-user/graphical-session-only.conf" \
+    "/usr/lib/systemd/user/${unit}.service.d/10-graphical-session-only.conf"
+done
+
 # PAM: the swaylock-plugin RPM ships /etc/pam.d/swaylock-plugin as a
 # %config(noreplace) file (lands in /usr/etc under ostree and merges at boot).
 # Only write a fallback if it is somehow absent, so we never conflict with the

--- a/build/hyprland/files/systemd-user/graphical-session-only.conf
+++ b/build/hyprland/files/systemd-user/graphical-session-only.conf
@@ -1,0 +1,9 @@
+# At logout the compositor dies before xdg-desktop-portal closes its open
+# portal sessions; that close call goes over D-Bus and re-activates the
+# backend when WAYLAND_DISPLAY is already gone, so the start fails and the
+# unit lingers in a failed state that fumon reports at the next login.
+# Requisite= makes activation outside a graphical session fail as a
+# dependency job, without running the binary or marking the unit failed.
+[Unit]
+Requisite=graphical-session.target
+After=graphical-session.target


### PR DESCRIPTION
At logout under Hyprland/uwsm the compositor exits first, killing xdg-desktop-portal-gtk with 'Broken pipe'. xdg-desktop-portal then tries to close its open portal sessions over D-Bus, which re-activates the backend after uwsm has scrubbed WAYLAND_DISPLAY; that start dies with 'cannot open display' and leaves the unit failed. fumon finds the stale failed unit at the next login and notifies.
plasma-xdg-desktop-portal-kde fails identically at the same instant.

Ship a systemd user drop-in for both backends gating activation on graphical-session.target. Requisite= (unlike Requires=) fails the mid-teardown activation as a dependency job without running the binary or marking the unit failed, and is a no-op for normal in-session activation. Mirrors the xdg-desktop-portal.service override already proven on styx; portals.conf backend routing is untouched.