### PR TITLE
fix(hyprland): gate xdg-desktop-portal-hyprland activation on session too

### DIFF
--- a/build/hyprland/build.sh
+++ b/build/hyprland/build.sh
@@ -181,7 +181,7 @@ install -Dm644 "${SCRIPT_DIR}/files/tmpfiles.d/swaylock-plugin-xkb.conf" \
 # and the doomed start ("cannot open display") leaves the unit failed for
 # fumon to report at the next login. See files/systemd-user/ for details.
 echo "Installing portal-backend graphical-session drop-ins"
-for unit in xdg-desktop-portal-gtk plasma-xdg-desktop-portal-kde; do
+for unit in xdg-desktop-portal-gtk plasma-xdg-desktop-portal-kde xdg-desktop-portal-hyprland; do
   install -Dm644 "${SCRIPT_DIR}/files/systemd-user/graphical-session-only.conf" \
     "/usr/lib/systemd/user/${unit}.service.d/10-graphical-session-only.conf"
 done


### PR DESCRIPTION
## Summary

Follow-up to #41: adds `xdg-desktop-portal-hyprland` to the loop installing the `graphical-session-only.conf` systemd user drop-in.

The Hyprland backend is subject to the same post-logout D-Bus re-activation as the gtk/kde backends, and xdph 1.3.12 additionally segfaults in `CPortalManager` teardown when the compositor socket dies under it (observed live at logout — `xdg-desktop-portal-hyprland.service: Failed with result 'core-dump'`), leaving a failed unit for fumon to report at the next login. `Requisite=graphical-session.target` keeps any mid-teardown activation from running the binary at all; normal in-session activation is unaffected.

The equivalent drop-in has been verified as a local user-level override on a production host — remove that local copy once an image with this change lands.

## Testing

- `bash -n build/hyprland/build.sh`
- Drop-in semantics verified live via a user-level override (unit loads with the override; portals active)