### PR TITLE
fix(ci): stop fromJSON on empty push outputs killing PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,8 +197,16 @@ jobs:
       - name: Sign container image
         if: github.event_name != 'pull_request' && success()
         run: |
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ steps.build_image.outputs.image }}@${TAGS}
+          # Extract the digest here rather than with fromJSON() in env: the runner
+          # evaluates step env templates even when the if-guard skips the step, so
+          # fromJSON('') on empty wretry outputs kills the whole job (seen on PR runs).
+          DIGEST="$(jq -r '.digest // empty' <<<"${PUSH_OUTPUTS}")"
+          if [[ -z "$DIGEST" ]]; then
+              echo "::error::push step returned no digest; cannot sign image"
+              exit 1
+          fi
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY "${{ steps.registry_case.outputs.lowercase }}/${{ steps.build_image.outputs.image }}@${DIGEST}"
         env:
-          TAGS: ${{ fromJSON(steps.push.outputs.outputs).digest }}
+          PUSH_OUTPUTS: ${{ steps.push.outputs.outputs }}
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}


### PR DESCRIPTION
## Summary

The cosign signing step in `build.yml` used `fromJSON(steps.push.outputs.outputs)` in its `env:` block to pull the pushed image digest. Two problems combine into a latent job-killer:

1. The GitHub runner evaluates a step's `env:` templates even when the step's `if:` guard would skip it (signing is skipped on `pull_request` events).
2. The `Wandalen/wretry` wrapper around `push-to-registry` sometimes returns empty `outputs` — observed on the two largest images (hyprland, workstation).

When both hit, `fromJSON('')` throws `Error reading JToken from JsonReader` and fails the whole job, even on PRs where signing never runs. This is what failed the hyprland and workstation checks on #43 — the buildah v2→v3 bump itself was fine.

## Change

- Pass the raw wretry outputs into the script as a plain-string env var (`PUSH_OUTPUTS`) — a plain template expansion can't throw.
- Extract the digest with `jq -r '.digest // empty'` inside the script, and fail with a clear `::error::` message if the digest is missing instead of a cryptic template crash.
- Retry wrapper and the `if:` guard are unchanged.

## Verification

PR checks exercise the full build + push path for all variants. The signing step itself only runs on `main` pushes; the first post-merge main build will confirm signing end-to-end (`cosign verify --key cosign.pub ghcr.io/syndr/phalanx-base:latest`).